### PR TITLE
Bug Fixes: Frogger Death Animation and Water Collision

### DIFF
--- a/Assets/Scenes/GameView.unity
+++ b/Assets/Scenes/GameView.unity
@@ -1439,7 +1439,7 @@ BoxCollider2D:
     drawMode: 2
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 16, y: 5}
+  m_Size: {x: 16, y: 7}
   m_EdgeRadius: 0
 --- !u!1001 &244201005
 PrefabInstance:

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -137,11 +137,17 @@ public class GameManager : MonoBehaviour
     private void GameOver()
     {
         gameOver = true;
-        frogger.gameObject.SetActive(false);
         StopAllCoroutines();
 
-        // Wait 2 seconds before restarting
-        Invoke(nameof(NewGame), 2f);
+        // Wait 1 second to show death sprite before deactivating Frogger
+        Invoke(nameof(DeactivateFrogger), 1f);
+    }
+
+    private void DeactivateFrogger()
+    {
+        frogger.gameObject.SetActive(false);
+        // Wait 1 more second before restarting
+        Invoke(nameof(NewGame), 1f);
     }
 
     private bool Cleared()

--- a/Assets/Sprites/UI/Heart.png.meta
+++ b/Assets/Sprites/UI/Heart.png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      Heart_0: 4606908045521496030
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 


### PR DESCRIPTION
## Demo

https://github.com/user-attachments/assets/e8ea023f-a951-415b-88a5-175e6d9de1e2

## Changes
This PR addresses two critical bugs affecting the Frogger game mechanics:

### 1. Death Sprite Not Showing on Game Over
- **Issue**: The Frogger death sprite was not visible when the player lost their last life
- **Fix**: Refactored the game over sequence to properly display the death animation
  - Added a 1-second delay before deactivating the Frogger object
  - Split the game over logic into two methods for better timing control
  - Total delay remains 2 seconds but now properly shows the death sprite

### 2. Water Collision in First Row
- **Issue**: Frogger was not dying when falling into water in the first row
- **Fix**: Adjusted the box collider to properly detect water collisions
  - Modified collider size and position to ensure consistent collision detection
  - Ensures Frogger dies appropriately when falling into water in all rows

## Testing
- Verified death sprite appears and remains visible for 1 second on game over
- Confirmed Frogger dies consistently when falling into water in all rows
- Tested game restart sequence timing and functionality

## Impact
These fixes improve the game's visual feedback and ensure consistent gameplay mechanics across all levels. 